### PR TITLE
fix(reviews): Remove duplicate customer review section

### DIFF
--- a/client/src/pages/ProductDetailPage.tsx
+++ b/client/src/pages/ProductDetailPage.tsx
@@ -35,7 +35,6 @@ import RelatedProducts from "@/components/RelatedProducts";
 import CustomerReviews, {
   CustomerReviewsHandles,
 } from "@/components/CustomerReviews";
-import FeaturedReviews from "@/components/FeaturedReviews";
 
 interface Review {
   _id: string;
@@ -724,7 +723,6 @@ const ProductDetailPage = () => {
                   See All
                 </button>
               </div>
-              <FeaturedReviews reviews={allReviews.slice(0, 3)} />
               <div className="text-center mt-8 mb-8">
                 <Button
                   variant="outline"


### PR DESCRIPTION
The product detail page was showing a "Featured Reviews" section and a "Customer Reviews" section, which displayed overlapping information and created a redundant user experience.

This change removes the `FeaturedReviews` component to eliminate the duplication. The main `CustomerReviews` component already displays all reviews, so no information is lost. The heading and buttons related to the review section have been preserved as per user feedback.